### PR TITLE
fix error: terminal 'gfxterm' isn't found

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,18 +1,6 @@
-main_workflow:
+workflow:
   steps:
     - branch_package:
         source_project: home:michael-chang:obs_scm-webhook
         source_package: grub2
         target_project: home:michael-chang:obs_scm-webhook:CI
-  filters:
-    event: pull_request
-rebuild_master:
-  steps:
-    - rebuild_package:
-        project: home:michael-chang:obs_scm-webhook
-        package: grub2
-  filters:
-    event: push
-    branches:
-      only:
-        - master

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,6 +1,23 @@
 workflow:
   steps:
-    - branch_package:
+    - link_package:
         source_project: home:michael-chang:obs_scm-webhook
         source_package: grub2
         target_project: home:michael-chang:obs_scm-webhook:CI
+    - configure_repositories:
+        project: home:michael-chang:obs_scm-webhook:CI
+        repositories:
+          - name: openSUSE_Tumbleweed
+            paths:
+              - target_project: openSUSE:Tumbleweed
+                target_repository: standard
+            architectures:
+              - x86_64
+              - i586
+          - name: openSUSE_Factory_PowerPC
+            paths:
+              - target_project: openSUSE:Factory:PowerPC
+                target_repository: standard
+            architectures:
+              - ppc64
+              - ppc64le

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -21,3 +21,16 @@ workflow:
             architectures:
               - ppc64
               - ppc64le
+          - name: openSUSE_Factory_ARM
+            paths:
+              - target_project: openSUSE:Factory:ARM
+                target_repository: standard
+            architectures:
+              - armv7l
+              - aarch64
+          - name: openSUSE_Factory_RISCV
+            paths:
+              - target_project: openSUSE:Factory:RISCV
+                target_repository: standard
+            architectures:
+              - riscv64

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,18 @@
+main_workflow:
+  steps:
+    - branch_package:
+        source_project: home:michael-chang:obs_scm-webhook
+        source_package: grub2
+        target_project: home:michael-chang:obs_scm-webhook:CI
+  filters:
+    event: pull_request
+rebuild_master:
+  steps:
+    - rebuild_package:
+        project: home:michael-chang:obs_scm-webhook
+        package: grub2
+  filters:
+    event: push
+    branches:
+      only:
+        - master

--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -511,6 +511,13 @@ script = {
 };
 
 script = {
+  name = '20_ppc_terminfo';
+  common = util/grub.d/20_ppc_terminfo.in;
+  installdir = grubconf;
+  condition = COND_HOST_LINUX;
+};
+
+script = {
   name = '30_os-prober';
   common = util/grub.d/30_os-prober.in;
   installdir = grubconf;

--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -172,7 +172,8 @@ fi
 
 # XXX: should this be deprecated at some point?
 if [ "x${GRUB_TERMINAL}" != "x" ] ; then
-  GRUB_TERMINAL_INPUT="${GRUB_TERMINAL}"
+# bnc#771393, bsc#1187565 - fix error: terminal 'gfxterm' isn't found.
+  GRUB_TERMINAL_INPUT="`echo ${GRUB_TERMINAL} | sed -e '/\bgfxterm\b/{s/\bconsole\b//g;s/\bgfxterm\b/console/}'`"
   GRUB_TERMINAL_OUTPUT="${GRUB_TERMINAL}"
 fi
 

--- a/util/grub.d/20_ppc_terminfo.in
+++ b/util/grub.d/20_ppc_terminfo.in
@@ -1,0 +1,114 @@
+#! /bin/sh
+set -e
+
+# grub-mkconfig helper script.
+# Copyright (C) 2006,2007,2008,2009,2010  Free Software Foundation, Inc.
+#
+# GRUB is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GRUB is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+bindir=@bindir@
+libdir=@libdir@
+. "@datadir@/@PACKAGE@/grub-mkconfig_lib"
+
+export TEXTDOMAIN=@PACKAGE@
+export TEXTDOMAINDIR=@localedir@
+
+X=80
+Y=24
+TERMINAL=ofconsole
+
+argument () {
+  opt=$1
+  shift
+
+  if test $# -eq 0; then
+      echo "$0: option requires an argument -- '$opt'" 1>&2
+      exit 1
+  fi
+  echo $1
+}
+
+check_terminfo () {
+
+  while test $# -gt 0
+  do
+    option=$1
+    shift
+
+    case "$option" in
+    terminfo | TERMINFO)
+        ;;
+
+    -g)
+        NEWXY=`argument $option "$@"`
+        NEWX=`echo $NEWXY | cut -d x -f 1`
+        NEWY=`echo $NEWXY | cut -d x -f 2`
+
+        if [ ${NEWX} -ge 80 ] ; then
+          X=${NEWX}
+        else
+          echo "Warning: ${NEWX} is less than the minimum size of 80"
+        fi
+
+        if [ ${NEWY} -ge 24 ] ; then
+          Y=${NEWY}
+        else
+          echo "Warning: ${NEWY} is less than the minimum size of 24"
+        fi
+
+        shift
+        ;;
+
+    *)
+#       # accept console or ofconsole
+#       if [ "$option" != "console" -a "$option" != "ofconsole" ] ; then
+#         echo "Error: GRUB_TERMINFO unknown console: $option"
+#         exit 1
+#       fi
+#       # perfer console
+#       TERMINAL=console
+        # accept ofconsole
+        if [ "$option" != "ofconsole" ] ; then
+          echo "Error: GRUB_TERMINFO unknown console: $option"
+          exit 1
+        fi
+        # perfer console
+        TERMINAL=ofconsole
+        ;;
+    esac
+
+  done
+
+}
+
+if ! uname -m | grep -q ppc ; then
+  exit 0
+fi
+
+if [ "x${GRUB_TERMINFO}" != "x" ] ; then
+  F1=`echo ${GRUB_TERMINFO} | cut -d " " -f 1`
+
+  if [ "${F1}" != "terminfo" ] ; then
+    echo "Error: GRUB_TERMINFO is set to \"${GRUB_TERMINFO}\" The first word should be terminfo."
+    exit 1
+  fi
+
+  check_terminfo ${GRUB_TERMINFO}
+fi
+
+cat << EOF
+  terminfo -g ${X}x${Y} ${TERMINAL}
+EOF


### PR DESCRIPTION
References: bnc#771393
Patch-Mainline: no

If set GRUB_TERMINAL="gfxterm", the error message "terminal
'gfxterm' isn't found" will be logged to screen. This is caused
by GRUB_TERMINAL_INPUT erroneously set to gfxterm. This patch
fixes the issue by not setting it.

v2:
Fix error gfxterm isn't found with multiple terminals (bsc#1187565)